### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/joint_qualification_controllers/src/checkout_controller.cpp
+++ b/joint_qualification_controllers/src/checkout_controller.cpp
@@ -35,9 +35,8 @@
 #include "joint_qualification_controllers/checkout_controller.h"
 #include "pluginlib/class_list_macros.h"
 
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, CheckoutController, 
-                        joint_qualification_controllers::CheckoutController, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::CheckoutController,
+                       pr2_controller_interface::Controller)
 
 using namespace std;
 using namespace joint_qualification_controllers;

--- a/joint_qualification_controllers/src/counterbalance_test_controller.cpp
+++ b/joint_qualification_controllers/src/counterbalance_test_controller.cpp
@@ -38,9 +38,8 @@
 #include <joint_qualification_controllers/counterbalance_test_controller.h>
 #include "pluginlib/class_list_macros.h"
 
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, CounterbalanceTestController, 
-                        joint_qualification_controllers::CounterbalanceTestController, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::CounterbalanceTestController,
+                       pr2_controller_interface::Controller)
 
 using namespace std;
 using namespace joint_qualification_controllers;

--- a/joint_qualification_controllers/src/head_position_controller.cpp
+++ b/joint_qualification_controllers/src/head_position_controller.cpp
@@ -37,10 +37,8 @@
 #include "pluginlib/class_list_macros.h"
 
 
-
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, HeadPositionController, 
-                        joint_qualification_controllers::HeadPositionController, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::HeadPositionController,
+                       pr2_controller_interface::Controller)
 
 using namespace std;
 using namespace joint_qualification_controllers;

--- a/joint_qualification_controllers/src/hysteresis_controller.cpp
+++ b/joint_qualification_controllers/src/hysteresis_controller.cpp
@@ -36,9 +36,8 @@
 #include "pluginlib/class_list_macros.h"
 #include "urdf_model/joint.h"
 
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, HysteresisController, 
-                        joint_qualification_controllers::HysteresisController, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::HysteresisController,
+                       pr2_controller_interface::Controller)
 
 #define MAX_DATA_POINTS 120000
 

--- a/joint_qualification_controllers/src/hysteresis_controller2.cpp
+++ b/joint_qualification_controllers/src/hysteresis_controller2.cpp
@@ -36,9 +36,8 @@
 #include "pluginlib/class_list_macros.h"
 #include "urdf_model/joint.h"
 
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, HysteresisController2, 
-                        joint_qualification_controllers::HysteresisController2, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::HysteresisController2,
+                       pr2_controller_interface::Controller)
 
 #define MAX_DATA_POINTS 120000
 

--- a/joint_qualification_controllers/src/joint_limit_calibration_controller.cpp
+++ b/joint_qualification_controllers/src/joint_limit_calibration_controller.cpp
@@ -39,9 +39,8 @@
 using namespace std;
 using namespace joint_qualification_controllers;
 
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, JointLimitCalibrationController, 
-                        joint_qualification_controllers::JointLimitCalibrationController, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::JointLimitCalibrationController,
+                       pr2_controller_interface::Controller)
 
 JointLimitCalibrationController::JointLimitCalibrationController()
 : robot_(NULL), last_publish_time_(0), state_(INITIALIZED), 

--- a/joint_qualification_controllers/src/motor_joint_calibration_controller.cpp
+++ b/joint_qualification_controllers/src/motor_joint_calibration_controller.cpp
@@ -36,9 +36,7 @@
 #include "ros/time.h"
 #include "pluginlib/class_list_macros.h"
 
-
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, MotorJointCalibrationController, 
-                        joint_qualification_controllers::MotorJointCalibrationController, pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::MotorJointCalibrationController, pr2_controller_interface::Controller)
 
 using namespace std;
 using namespace joint_qualification_controllers;

--- a/joint_qualification_controllers/src/wrist_difference_controller.cpp
+++ b/joint_qualification_controllers/src/wrist_difference_controller.cpp
@@ -35,9 +35,8 @@
 #include "joint_qualification_controllers/wrist_difference_controller.h"
 #include "urdf_model/joint.h"
 
-PLUGINLIB_DECLARE_CLASS(joint_qualification_controllers, WristDifferenceController, 
-                        joint_qualification_controllers::WristDifferenceController, 
-                        pr2_controller_interface::Controller)
+PLUGINLIB_EXPORT_CLASS(joint_qualification_controllers::WristDifferenceController,
+                       pr2_controller_interface::Controller)
 
 #define MAX_DATA_POINTS 120000
 


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions