### PR TITLE
Fixed bugs to run PR2 couter balance adjustment on Indigo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-pr2_self_test [![Build Status](https://travis-ci.com/PR2/pr2_self_test.svg?branch=hydro-devel)](https://travis-ci.org/PR2/pr2_self_test)
+pr2_self_test [![Build Status](https://travis-ci.com/PR2/pr2_self_test.svg?branch=hydro-devel)](https://travis-ci.com/PR2/pr2_self_test)
 ========================================================================================================================================

--- a/joint_qualification_controllers/CMakeLists.txt
+++ b/joint_qualification_controllers/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(joint_qualification_controllers)
-find_package(catkin REQUIRED COMPONENTS pr2_controller_interface pr2_mechanism_model pr2_hardware_interface control_toolbox roscpp robot_mechanism_controllers pluginlib std_msgs sensor_msgs realtime_tools urdf)
+find_package(catkin REQUIRED COMPONENTS pr2_controller_interface pr2_mechanism_model pr2_hardware_interface control_toolbox roscpp robot_mechanism_controllers pluginlib std_msgs sensor_msgs realtime_tools urdf message_generation)
 
 
 include_directories(include ${catkin_INCLUDE_DIRS})
@@ -41,7 +41,7 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp ${catkin_EXPORTED_TARGET
 # TODO: fill in what other packages will need to use this package
 catkin_package(
     DEPENDS pr2_controller_interface pr2_mechanism_model pr2_hardware_interface control_toolbox roscpp robot_mechanism_controllers pluginlib std_msgs sensor_msgs realtime_tools urdf
-    CATKIN_DEPENDS # TODO
+    CATKIN_DEPENDS message_runtime # TODO
     INCLUDE_DIRS include # TODO include
     LIBRARIES ${PROJECT_NAME}# TODO
 )

--- a/joint_qualification_controllers/package.xml
+++ b/joint_qualification_controllers/package.xml
@@ -20,6 +20,7 @@
   <build_depend>pr2_mechanism_model</build_depend>
   <build_depend>pr2_hardware_interface</build_depend>
   <build_depend>control_toolbox</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>robot_mechanism_controllers</build_depend>
   <build_depend>pluginlib</build_depend>
@@ -36,6 +37,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>robot_mechanism_controllers</run_depend>
   <run_depend>pluginlib</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>realtime_tools</run_depend>

--- a/pr2_counterbalance_check/CMakeLists.txt
+++ b/pr2_counterbalance_check/CMakeLists.txt
@@ -54,3 +54,5 @@ catkin_package(
     LIBRARIES # TODO
 )
 
+catkin_python_setup()
+

--- a/pr2_counterbalance_check/CMakeLists.txt
+++ b/pr2_counterbalance_check/CMakeLists.txt
@@ -56,3 +56,7 @@ catkin_package(
 
 catkin_python_setup()
 
+install(DIRECTORY cb_data config launch scripts test training util
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS
+)

--- a/pr2_counterbalance_check/CMakeLists.txt
+++ b/pr2_counterbalance_check/CMakeLists.txt
@@ -13,9 +13,6 @@ find_package(catkin REQUIRED COMPONENTS joint_qualification_controllers rospy st
 # CATKIN_MIGRATION: removed during catkin migration
 # include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
 
-catkin_python_setup()
-set(ROSPACK_MAKEDIST true)
-
 # Append to CPACK_SOURCE_IGNORE_FILES a semicolon-separated list of
 # directories (or patterns, but directories should suffice) that should
 # be excluded from the distro.  This is not the place to put things that

--- a/pr2_counterbalance_check/test/cb_analysis_test.py
+++ b/pr2_counterbalance_check/test/cb_analysis_test.py
@@ -39,7 +39,7 @@ from __future__ import division
 PKG = 'pr2_counterbalance_check'
 import roslib
 
-from pr2_counterbalance_check import *
+from pr2_counterbalance_check.counterbalance_analysis import *
 
 import copy
 import os, sys

--- a/pr2_self_test_msgs/CMakeLists.txt
+++ b/pr2_self_test_msgs/CMakeLists.txt
@@ -38,6 +38,13 @@ add_message_files(
   TestValue.msg
 )
 
+add_service_files(
+  FILES
+  ConfirmConf.srv
+  ScriptDone.srv
+  TestResult.srv
+)
+
 generate_messages()
 # CATKIN_MIGRATION
 # use bloom tool
@@ -51,7 +58,7 @@ generate_messages()
 # TODO: fill in what other packages will need to use this package
 catkin_package(
     DEPENDS # TODO add dependencies
-    CATKIN_DEPENDS # TODO
+    CATKIN_DEPENDS message_runtime # TODO
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )


### PR DESCRIPTION
I fixed several bugs to run PR2 counter balance adjustment on Indigo
- add message_generation and message_runtime
- add srvs
- add python setup.py
- add install in pr2_counterbalance_check


cc. @YutoUchimi