### PR TITLE
[pr2_motor_diagnostic_tool] fix package.xml in pr2_motor_diagnostic_tool

### DIFF
--- a/pr2_motor_diagnostic_tool/package.xml
+++ b/pr2_motor_diagnostic_tool/package.xml
@@ -23,6 +23,7 @@
   <build_depend>pr2_mechanism_msgs</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>ethercat_hardware</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>rospy</run_depend>
@@ -33,6 +34,7 @@
   <run_depend>pr2_mechanism_msgs</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>ethercat_hardware</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>rospy</test_depend> -->


### PR DESCRIPTION
- add `message_generation` and `message_runtime` in `pr2_motor_diagnostic_tool/package.xml`