### PR TITLE
Fix travis build and add noetic allow-failure test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=focal ARCH=amd64
 matrix:
   allow_failures:
+    - env: ROS_DISTRO_NAME=indigo OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
     - env: ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=focal ARCH=amd64
 install:
   # either install the latest released version of ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ env:
     - JOB_PATH=/tmp/devel_job
     - ABORT_ON_TEST_FAILURE=1
   matrix:
-    - ROS_DISTRO_NAME=indigo  OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
     - ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
     - ROS_DISTRO_NAME=melodic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64
+    - ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=focal ARCH=amd64
 matrix:
   allow_failures:
-    - env: ROS_DISTRO_NAME=melodic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64
+    - env: ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=focal ARCH=amd64
 install:
   # either install the latest released version of ros_buildfarm
   - pip install ros_buildfarm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@
 # https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/jobs/prerelease_jobs.rst
 # while this doesn't require sudo we don't want to run within a Docker container
 sudo: true
-dist: trusty
+dist: bionic
 language: python
 python:
-  - "3.4"
+  - "3.6"
 env:
   global:
     - JOB_PATH=/tmp/devel_job

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - env: ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=focal ARCH=amd64
 install:
   # either install the latest released version of ros_buildfarm
-  - pip install ros_buildfarm
+  - pip install ros_buildfarm>=3.0.0
   # or checkout a specific branch
   #- git clone -b master https://github.com/ros-infrastructure/ros_buildfarm /tmp/ros_buildfarm
   #- pip install /tmp/ros_buildfarm
@@ -31,15 +31,15 @@ install:
   # run devel job for a ROS repository with the same name as this repo
   - export REPOSITORY_NAME=`basename $TRAVIS_BUILD_DIR`
   # use the code already checked out by Travis
-  - mkdir -p $JOB_PATH/catkin_workspace/src
-  - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/catkin_workspace/src/
+  - mkdir -p $JOB_PATH/ws/src
+  - cp -R $TRAVIS_BUILD_DIR $JOB_PATH/ws/src/
   # generate the script to run a pre-release job for that target and repo
   - generate_prerelease_script.py https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml $ROS_DISTRO_NAME default $OS_NAME $OS_CODE_NAME $ARCH  --output-dir $JOB_PATH
   # run the actual job which involves Docker
   - cd $JOB_PATH; sh ./prerelease.sh -y
 script:
   # get summary of test results
-  - /tmp/catkin/bin/catkin_test_results $JOB_PATH/catkin_workspace/test_results --all
+  - /tmp/catkin/bin/catkin_test_results $JOB_PATH/ws/test_results --all
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - JOB_PATH=/tmp/devel_job
     - ABORT_ON_TEST_FAILURE=1
   matrix:
+    - ROS_DISTRO_NAME=indigo OS_NAME=ubuntu OS_CODE_NAME=trusty ARCH=amd64
     - ROS_DISTRO_NAME=kinetic OS_NAME=ubuntu OS_CODE_NAME=xenial ARCH=amd64
     - ROS_DISTRO_NAME=melodic OS_NAME=ubuntu OS_CODE_NAME=bionic ARCH=amd64
     - ROS_DISTRO_NAME=noetic OS_NAME=ubuntu OS_CODE_NAME=focal ARCH=amd64


### PR DESCRIPTION
fix travis build
- add noetic test (allow failure)
- do not allow failure on melodic test (because it is released)
- change `.travis.yml` for `ros_buildfarm>=3.0.0`