### PR TITLE
fix typo: pr2_etherCAT -> pr2_ethercat

### DIFF
--- a/pr2_counterbalance_check/scripts/cb_check.py
+++ b/pr2_counterbalance_check/scripts/cb_check.py
@@ -68,7 +68,7 @@ class CounterbalanceCheck(object):
         self._motors_halted = True
         self._data = None
 
-        self.motors_topic = rospy.Subscriber('pr2_etherCAT/motors_halted', Bool, self._motors_cb)
+        self.motors_topic = rospy.Subscriber('pr2_ethercat/motors_halted', Bool, self._motors_cb)
         self.data_topic = rospy.Subscriber('cb_test_data', CounterbalanceTestData, self._data_callback)
 
         self._model_file = model_file

--- a/pr2_counterbalance_check/scripts/cb_qual_test.py
+++ b/pr2_counterbalance_check/scripts/cb_qual_test.py
@@ -55,7 +55,7 @@ class CounterbalanceAnalyzer:
         self._motors_halted = True
         self._data = None
 
-        self.motors_topic = rospy.Subscriber('pr2_etherCAT/motors_halted', Bool, self._motors_cb)
+        self.motors_topic = rospy.Subscriber('pr2_ethercat/motors_halted', Bool, self._motors_cb)
         self.data_topic = rospy.Subscriber('cb_test_data', CounterbalanceTestData, self._data_callback)
         self._result_service = rospy.ServiceProxy('test_result', TestResult)
 


### PR DESCRIPTION
`pr2_etherCAT` -> `pr2_ethercat`

`pr2_ethercat` node name is changed in this commit.
https://github.com/PR2/pr2_robot/commit/f7f0960ec413a61ec65ed81544214f223b3057d2