### PR TITLE
set lower minimum cmake version

### DIFF
--- a/joint_qualification_controllers/CMakeLists.txt
+++ b/joint_qualification_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 2.8.3)
 project(joint_qualification_controllers)
 find_package(catkin REQUIRED COMPONENTS pr2_controller_interface pr2_mechanism_model pr2_hardware_interface control_toolbox roscpp robot_mechanism_controllers pluginlib std_msgs sensor_msgs realtime_tools urdf message_generation)
 


### PR DESCRIPTION
we don't need cmake `3` for this package.
indigo PR2 fails to build with this minimum cmake version.
https://launchpad.net/ubuntu/trusty/+package/cmake